### PR TITLE
ElvUI & AceGUIContainer Error Fix

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -397,15 +397,17 @@ function GUI:New()
     self.btn_share:SetText("Share");
     self.btn_share:SetCallback("OnClick", WBT.GetSafeSpawnAnnouncerWithCooldown());
 
-    self.gui_container = GUI.AceGUI:Create("SimpleGroup");
-    self.gui_container.frame:SetFrameStrata("LOW");
-    self.gui_container:AddChild(self.window);
     self.btn_container = GUI.AceGUI:Create("SimpleGroup");
+	self.btn_container.frame:SetFrameStrata("LOW");
     self.btn_container:SetLayout("flow");
     self.btn_container:SetWidth(self.width);
     self.btn_container:AddChild(self.btn_opts);
     self.btn_container:AddChild(self.btn_req);
     self.btn_container:AddChild(self.btn_share);
+	
+    self.gui_container = GUI.AceGUI:Create("SimpleGroup");
+    self.gui_container.frame:SetFrameStrata("LOW");
+    self.gui_container:AddChild(self.window);
     self.gui_container:AddChild(self.btn_container);
 
     -- I didn't notice any "OnClose" for the gui_container

--- a/GUI.lua
+++ b/GUI.lua
@@ -416,6 +416,13 @@ function GUI:New()
     self.window:SetCallback("OnClose", function()
         self:CleanUpWidgetsAndRelease();
     end);
+	
+    self.window.title:SetScript("OnMouseDown", function(this)
+        if self.window.frame:IsMovable() then
+            this:GetParent():StartMoving();
+        end
+        GUI.AceGUI:ClearFocus();
+    end);
 
     self:CreateLabels();
     self:InitPosition();


### PR DESCRIPTION
- Updating Ace3 was probably not necessary, but I did it to see if #38 would resolve itself.
- After manually setting the FrameStata for the btn_container to "LOW", i could no longer reproduce any bugs with ElvUI.
- By overwriting the Ace3 widget function, the window now only tries to move if it is actually movable.