### PR TITLE
Improvements for when shard is unknown

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
         lua5.3 \
-        vim
+        vim \
+        git
 
 
 # ==============================================================================

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,19 @@
 {
-    "name": "dev_wbt",
+    "name": "wbt_dev",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {}
     },
-
-    "settings": {},
-
-    "extensions": [
-	],
-
+    "customizations": {
+        "vscode": {
+            // NOTE: If git doesn't work, follow instructions:
+            // https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials
+            "settings": {},
+            "extensions": [
+				"actboy168.lua-debug",
+				"sumneko.lua"
+			]
+        }
+    },
     "postCreateCommand": "echo Lua container for WBT development now set up."
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 *.swo
 .release
-.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lua",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/UnitTest.lua",
+            "stopOnEntry": false,
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
         "IsShiftKeyDown",
         "DEFAULT_CHAT_FRAME"
     ],
-    "Lua.workspace.ignoreDir": [ "/libs", "/Com.lua" ]
+    "Lua.workspace.ignoreDir": [ "/libs", "/Com.lua" ],
+    "Lua.completion.enable": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "Lua.diagnostics.disable": [ "need-check-nil" ],
+    "Lua.diagnostics.ignoredFiles": "Disable",
+    "Lua.diagnostics.globals": [
+        "g_test_settings",
+        "strsplit",
+        "GetNumSavedWorldBosses",
+        "GetSavedWorldBossInfo",
+        "C_QuestLog",
+        "strsub",
+        "hooksecurefunc",
+        "PlaySound",
+        "SendChatMessage",
+        "ReloadUI",
+        "IsControlKeyDown",
+        "IsShiftKeyDown",
+        "DEFAULT_CHAT_FRAME"
+    ],
+    "Lua.workspace.ignoreDir": [ "/libs", "/Com.lua" ]
+}

--- a/Com.lua
+++ b/Com.lua
@@ -138,8 +138,7 @@ end
 function Com.OnCommReceivedRR(prefix, message, distribution, sender)
     local name, t_death = Com.ParseKillMessage(message);
     local guid = KillInfo.CreateGUID(name);
-    local ignore_cyclic = true;
-    if WBT.IsBoss(name) and not WBT.IsDead(guid, ignore_cyclic) then
+    if WBT.IsBoss(name) and not WBT.HasKillInfoExpired(guid) then
         WBT.PutOrUpdateKillInfo(name, t_death);
         WBT:Print("Received " .. WBT.GetColoredBossName(name) .. " timer from: " .. sender);
     end

--- a/GUI.lua
+++ b/GUI.lua
@@ -349,7 +349,7 @@ function GUI:Update(event)
 
     self:UpdateGUIVisibility();
 
-    if not(self.visible) then
+    if not self.visible then
         return;
     end
 

--- a/GUI.lua
+++ b/GUI.lua
@@ -234,20 +234,17 @@ function GUI:AddNewLabel(guid, kill_info)
     self.window:AddChild(label);
 end
 
-function GUI:RemoveLabel(guid)
-    -- This table is always a set, and can therefore be treated as such.
-    Util.RemoveFromSet(self.window.children, self.labels[guid]);
-    self.labels[guid]:Release();
-    self.labels[guid] = nil;
-end
-
 function GUI:Rebuild()
     if self.labels == nil then
         return; -- GUI hasn't been built, so nothing to rebuild.
     end
 
+    -- Clear all labels.
     for guid, _ in pairs(self.labels) do
-        self:RemoveLabel(guid);
+        -- NOTE: Don't try to remove specific children. That's too Ace internal.
+        table.remove(self.window.children);
+        self.labels[guid]:Release();
+        self.labels[guid] = nil;
     end
 
     self:Update();

--- a/GUI.lua
+++ b/GUI.lua
@@ -311,10 +311,15 @@ function GUI:UpdateContent()
                 end
             end
         else
+            -- Remove label:
             if label.userdata.added then
                 -- The label is apparently not automatically removed from the
                 -- self.window.children table, so it has to be done manually.
                 self:RemoveLabel(guid, label);
+                if self.update_event == WBT.UpdateEvents.SHARD_DETECTED then
+                    local boss_name = WBT.GetColoredBossName(WBT.db.global.kill_infos[guid].boss_name);
+                    WBT.Logger.Info("Timer for " .. boss_name .. " was hidden because it's not for the current shard.")
+                end
             end
         end
     end
@@ -335,7 +340,10 @@ function GUI:UpdateContent()
     end
 end
 
-function GUI:Update()
+-- @param event: Optional event specifier.
+function GUI:Update(event)
+    self.update_event = event or WBT.UpdateEvents.UNSPECIFIED;
+
     self:UpdateGUIVisibility();
 
     if not(self.visible) then
@@ -344,6 +352,8 @@ function GUI:Update()
 
     self:LockOrUnlock();
     self:UpdateContent();
+
+    self.update_event = WBT.UpdateEvents.UNSPECIFIED;
 end
 
 function GUI:UpdatePosition(gp)
@@ -456,6 +466,8 @@ function GUI:New()
     if self.gui_container then
         self.gui_container:Release();
     end
+
+    self.update_event = WBT.UpdateEvents.UNSPECIFIED;
 
     self.released = false;
 

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -292,7 +292,7 @@ end
 function KillInfo:IsOnCurrentShard()
     if self:HasUnknownShard() then
         return false;
-    elseif Options.assume_realm_keeps_shard.get() and (self.shard_id == WBT.GetSavedShardID()) then
+    elseif Options.assume_realm_keeps_shard.get() and (self.shard_id == WBT.GetSavedShardID(WBT.GetCurrentMapId())) then
         return true;
     else
         return self.shard_id == WBT.GetCurrentShardID();
@@ -306,10 +306,6 @@ function KillInfo:IsOnSavedRealmShard()
         return false;
     end
 
-    local crd = WBT.db.global.connected_realms_data[WBT.GetRealmKey()];
-    if crd == nil then
-        return false;
-    end
     local zone_id = WBT.BossData.Get(self.boss_name).map_id;
-    return crd.shard_id_per_zone[zone_id] == self.shard_id;
+    return WBT.GetSavedShardID(zone_id) == self.shard_id;
 end

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -238,7 +238,7 @@ end
 
 function KillInfo:ShouldAutoAnnounce()
     return WBT.db.global.auto_announce
-            and Util.SetContainsValue(self.announce_times, self.remaining_time)
+            and Util.SetUtil.ContainsValue(self.announce_times, self.remaining_time)
             and WBT.PlayerIsInBossPerimiter(self.boss_name)
             and WBT.BossData.Get(self.boss_name).auto_announce
             and self:IsSafeToShare({});

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -271,7 +271,7 @@ function KillInfo:InTimeWindow(from, to)
     return from <= t_now and t_now <= to;
 end
 
-function KillInfo:ShouldMakeRespawnAlertPlay(offset)
+function KillInfo:ShouldRespawnAlertPlayNow(offset)
     local t_now = GetServerTime();
     local until_time_offset = self.until_time - offset;
     local trigger = self:InTimeWindow(until_time_offset, until_time_offset + 1)

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -172,13 +172,13 @@ function KillInfo:IsSafeToShare(error_msgs)
         table.insert(error_msgs, "Timer doesn't have a shard ID. (This means that it was shared to you by a "
                               .. "player with an old version of WBT.)");  -- WBT v.1.9 or less.
     else
-        local cur_shard_id = WBT.GetCurrentShardID();
-        if not cur_shard_id then
+        local shard_id = WBT.GetCurrentShardID();
+        if WBT.IsUnknownShard(shard_id) then
             table.insert(error_msgs, "Current shard ID is unknown. It will automatically be detected when "
                                   .. "mousing over an NPC.");
-        elseif self.shard_id ~= cur_shard_id then
+        elseif self.shard_id ~= shard_id then
             table.insert(error_msgs, "Kill was made on shard ID " .. self.shard_id
-                                  .. ", but you are on " .. cur_shard_id .. ".");
+                                  .. ", but you are on " .. shard_id .. ".");
         end
     end
 
@@ -307,7 +307,7 @@ function KillInfo:Expired()
 end
 
 function KillInfo:IsOnCurrentShard()
-    return self.shard_id and (self.shard_id == WBT.GetCurrentShardID());
+    return not self:HasUnknownShard() and (self.shard_id == WBT.GetCurrentShardID());
 end
 
 function KillInfo:HasUnknownShard()

--- a/Options.lua
+++ b/Options.lua
@@ -295,11 +295,12 @@ function Options.InitializeOptionsTable()
             name = -- Hint_1
                     "- Press the " .. Util.ColoredString(Util.COLOR_ORANGE, "Req.") .. " " ..
                     "button to request timers from other nearby WBT " ..
-                    "users. Since 8.2.5 this no longer causes automatic sharing. The other player must manually " ..
+                    "users. Since 8.2.5 there is no longer any automatic sharing, so other players must manually " ..
                     "share the timer by using the " .. Util.ColoredString(Util.COLOR_ORANGE, "Share") .. " button.\n" ..
                     -- Hint_2
-                    "- Click a timer that is shown in " .. Util.ColoredString(Util.COLOR_RED, "red") .. " " ..
-                    "to reset that (and only that) timer.",
+                    "- Control-click a timer that is shown in " .. Util.ColoredString(Util.COLOR_RED, "red") .. " to reset it.\n" ..
+                    -- Hint_3
+                    "- Control-shift-click any timer to reset it.",
             order = t_cnt:plusplus(),
             type = "description",
             fontSize = "medium",
@@ -425,7 +426,7 @@ function Options.InitializeOptionsTable()
         spawn_alert_sec_before = {
             name = "Alert sec before spawn",
             order = t_cnt:plusplus(),
-            desc = "How many seconds before boss spawns that alerts should happen",
+            desc = "How many seconds before boss spawn that alert will happen",
             type = "range",
             min = 0,
             max = 60*5,

--- a/Options.lua
+++ b/Options.lua
@@ -159,19 +159,20 @@ end
 function Options.InitializeItems()
     local logger_opts = WBT.Logger.options_tbl;
     local sound_opts =  Sound.sound_tbl;
-    Options.lock                   = ToggleItem:New("lock",                "GUI lock is now");
-    Options.show_gui               = ToggleItem:New("show_gui",            nil);
-    Options.sound                  = ToggleItem:New("sound_enabled",       "Sound is now");
-    Options.multi_realm            = ToggleItem:New("multi_realm",         "Show timers for other shards option is now");
-    Options.show_boss_zone_only    = ToggleItem:New("show_boss_zone_only", "Only show GUI in boss zone mode is now");
-    Options.cyclic                 = ToggleItem:New("cyclic",              "Cyclic mode is now");
-    Options.highlight              = ToggleItem:New("highlight",           "Highlighting of current zone is now");
-    Options.show_saved             = ToggleItem:New("show_saved",          "Showing if saved on boss (on timer) is now");
-    Options.show_realm             = ToggleItem:New("show_realm",          "Showing realm on which timer was recorded is now");
-    Options.dev_silent             = ToggleItem:New("dev_silent",          "Silent mode is now");
-    Options.log_level              = SelectItem:New("log_level",             "Log level is now",         logger_opts.tbl, logger_opts.keys.option, logger_opts.keys.log_level, WBT.defaults.global.log_level);
-    Options.spawn_alert_sound      = SelectItem:New("spawn_alert_sound",     "Spawn alert sound is now", sound_opts.tbl,  sound_opts.keys.option,  sound_opts.keys.file_id,    WBT.defaults.global.spawn_alert_sound);
-    Options.spawn_alert_sec_before = RangeItem:New("spawn_alert_sec_before", "Spawn alert sound sec before is now", WBT.defaults.global.spawn_alert_sec_before);
+    Options.lock                     = ToggleItem:New("lock",                     "GUI lock is now");
+    Options.show_gui                 = ToggleItem:New("show_gui",                 nil);
+    Options.sound                    = ToggleItem:New("sound_enabled",            "Sound is now");
+    Options.assume_realm_keeps_shard = ToggleItem:New("assume_realm_keeps_shard", "Option to assume realms do not change shards is now");
+    Options.multi_realm              = ToggleItem:New("multi_realm",              "Option to show timers for other shards is now");
+    Options.show_boss_zone_only      = ToggleItem:New("show_boss_zone_only",      "Only show GUI in boss zone mode is now");
+    Options.cyclic                   = ToggleItem:New("cyclic",                   "Cyclic mode is now");
+    Options.highlight                = ToggleItem:New("highlight",                "Highlighting of current zone is now");
+    Options.show_saved               = ToggleItem:New("show_saved",               "Showing if saved on boss (on timer) is now");
+    Options.show_realm               = ToggleItem:New("show_realm",               "Showing realm on which timer was recorded is now");
+    Options.dev_silent               = ToggleItem:New("dev_silent",               "Silent mode is now");
+    Options.log_level                = SelectItem:New("log_level",                "Log level is now",         logger_opts.tbl, logger_opts.keys.option, logger_opts.keys.log_level, WBT.defaults.global.log_level);
+    Options.spawn_alert_sound        = SelectItem:New("spawn_alert_sound",        "Spawn alert sound is now", sound_opts.tbl,  sound_opts.keys.option,  sound_opts.keys.file_id,    WBT.defaults.global.spawn_alert_sound);
+    Options.spawn_alert_sec_before   = RangeItem:New("spawn_alert_sec_before",    "Spawn alert sound sec before is now", WBT.defaults.global.spawn_alert_sec_before);
      -- Wrapping in some help printing for cyclic mode.
     local cyclic_set_temp = Options.cyclic.set;
     Options.cyclic.set = function(state) cyclic_set_temp(state); WBT:Print(CYCLIC_HELP_TEXT); end
@@ -292,13 +293,13 @@ function Options.InitializeOptionsTable()
         },
         sharing_explanation_body = {
             name = -- Hint_1
-                    "- Press the " .. Util.ColoredString(Util.COLOR_ORANGE, "Req.") ..
-                    " button to request timers from other nearby " ..  Util.ColoredString(Util.COLOR_ORANGE, "WBT") ..
-                    " users. Since 8.2.5 this no longer causes automatic sharing. The other player must manually " ..
-                    " share the timer by using the " .. Util.ColoredString(Util.COLOR_ORANGE, "Share") .. " button.\n" ..
+                    "- Press the " .. Util.ColoredString(Util.COLOR_ORANGE, "Req.") .. " " ..
+                    "button to request timers from other nearby WBT " ..
+                    "users. Since 8.2.5 this no longer causes automatic sharing. The other player must manually " ..
+                    "share the timer by using the " .. Util.ColoredString(Util.COLOR_ORANGE, "Share") .. " button.\n" ..
                     -- Hint_2
-                    "- Click a timer that is shown in " .. Util.ColoredString(Util.COLOR_RED, "red") ..
-                    " to reset that (and only that) timer.",
+                    "- Click a timer that is shown in " .. Util.ColoredString(Util.COLOR_RED, "red") .. " " ..
+                    "to reset that (and only that) timer.",
             order = t_cnt:plusplus(),
             type = "description",
             fontSize = "medium",
@@ -348,6 +349,16 @@ function Options.InitializeOptionsTable()
             width = "full",
             set = function(info, val) Options.cyclic:Toggle(); end,
             get = function(info) return Options.cyclic.get(); end,
+        },
+        assume_realm_keeps_shard = {
+            name = "Assume realms do not change shards",
+            order = t_cnt:plusplus(),
+            desc = "Uses the last known shard ID for this realm when the current shard ID is unknown. " ..
+                   "This may lead to incorrect timers.",
+            type = "toggle",
+            width = "full",
+            set = function(info, val) Options.assume_realm_keeps_shard:Toggle(); end,
+            get = function(info) return Options.assume_realm_keeps_shard.get(); end,
         },
         multi_realm = {  -- NOTE: Should be named multi_shard, but to keep user set option values, it was not renamed.
             name = "Show timers for other shards",

--- a/Options.lua
+++ b/Options.lua
@@ -426,7 +426,7 @@ function Options.InitializeOptionsTable()
         spawn_alert_sec_before = {
             name = "Alert sec before spawn",
             order = t_cnt:plusplus(),
-            desc = "How many seconds before boss spawn that alert will happen",
+            desc = "How many seconds before boss spawn the alert will happen",
             type = "range",
             min = 0,
             max = 60*5,

--- a/Options.lua
+++ b/Options.lua
@@ -355,11 +355,7 @@ function Options.InitializeOptionsTable()
             desc = "Shows timers for other shards",
             type = "toggle",
             width = "full",
-            set =
-                function(info, val)
-                    Options.multi_realm:Toggle();
-                    GUI:UpdateWindowTitle();
-                end,
+            set = function(info, val) Options.multi_realm:Toggle(); end,
             get = function(info) return Options.multi_realm.get(); end,
         },
         highlight = {

--- a/Options.lua
+++ b/Options.lua
@@ -236,7 +236,7 @@ function Options.SlashHandler(input)
         WBT.RequestKillData();
     elseif arg1 == "sound" then
         local sound_type_args = {Sound.SOUND_CLASSIC, Sound.SOUND_FANCY};
-        if Util.SetContainsValue(sound_type_args, arg2) then
+        if Util.SetUtil.ContainsValue(sound_type_args, arg2) then
             WBT.db.global.sound_type = arg2;
             WBT:Print("SoundType: " .. arg2);
         else

--- a/Options.lua
+++ b/Options.lua
@@ -235,7 +235,7 @@ function Options.SlashHandler(input)
     elseif arg1 == "request" then
         WBT.RequestKillData();
     elseif arg1 == "sound" then
-        sound_type_args = {Sound.SOUND_CLASSIC, Sound.SOUND_FANCY};
+        local sound_type_args = {Sound.SOUND_CLASSIC, Sound.SOUND_FANCY};
         if Util.SetContainsValue(sound_type_args, arg2) then
             WBT.db.global.sound_type = arg2;
             WBT:Print("SoundType: " .. arg2);

--- a/Test.lua
+++ b/Test.lua
@@ -14,7 +14,8 @@
 # Before push to master tests:
 1. Unit tests must pass: UnitTests.lua
 2. For any changed module, perform relevant tests.
-3. Manually check that happy path and most edge cases work. If necessary also write down a test for it here.
+3. Manually check that happy path and most edge cases work. If necessary also
+   write down a test for it here.
 
 #--------------------------------------------------------------------------------
 
@@ -23,23 +24,29 @@
 2. Share timer with other player via button. Check that they receive it.
 
 # GUI tests:
-1. Go to non-boss zone and run StartTimers25. Check that GUI looks OK and that you don't get any alerts. Change options arbitrarily and check that GUI looks OK.
-    a. Repeat in boss zone. Check that you get alerts.
+1. Go to non-boss zone and run StartTimers25. Check that GUI looks OK and that
+   you don't get any alerts. Change options arbitrarily and check that GUI
+   looks OK.
+      a. Repeat in boss zone. Check that you get alerts.
 2. After (1.):
-    a. /reload and check that everything looks OK.
-    b. Relog and check that everything looks OK.
+      a. /reload and check that everything looks OK.
+      b. Relog and check that everything looks OK.
 3. Spam all buttons exploratorily. Check that nothing breaks.
 
 # Backend tests
 1. Run StartTimers25. Check that GUI behaves as expected. 
 
 # Logger tests
-1. Clear all timers. Enter the perimiter of some boss and try to share. Check that Info message looks OK.
-2. Run StartTimers4 and let it expire. Enter the perimiter of some boss and try to share. Check that Info message looks OK.
+1. Clear all timers. Enter the perimiter of some boss and try to share. Check
+   that Info message looks OK.
+2. Run StartTimers4 and let it expire. Enter the perimiter of some boss and try
+   to share. Check that Info message looks OK.
 
 # CLI tests
-1. Set log level to 'Nothing' via CLI. Check that GUI options shows correct value. Repeat Logger tests and verify that nothing is printed.
-2. Set log level to 'Info' via CLI. Repeat (1.) but now check that the logger tests actually pass.
+1. Set log level to 'Nothing' via CLI. Check that GUI options shows correct
+   value. Repeat Logger tests and verify that nothing is printed.
+2. Set log level to 'Info' via CLI. Repeat (1.) but now check that the logger
+   tests actually pass.
 
 ]]--
 

--- a/Test.lua
+++ b/Test.lua
@@ -69,11 +69,11 @@ local function AdjustedDeathTime(name, dt_expire)
 end
 
 local function CurrentShardID()
-    local cur_shard_id = WBT.GetCurrentShardID();
-    if not cur_shard_id then
-        print("WARNING: WBT test function running with shard_id=nil");
+    local shard_id = WBT.GetCurrentShardID();
+    if WBT.IsUnknownShard(shard_id) then
+        print("WARNING: WBT test function running with unknown shard_id");
     end
-    return cur_shard_id;
+    return shard_id;
 end
 
 local function StartSim(name, dt_expire)
@@ -166,3 +166,13 @@ function Test.ShareLegacyTimer(shard_id_or_nil)
     SendChatMessage(msg, "SAY");
 end
 dshare = Test.ShareLegacyTimer;
+
+function Test.ResetOpts()
+    for k, v in pairs(WBT.defaults.global) do
+        if k ~= "kill_infos" then
+            WBT.db.global[k] = v;
+        end
+    end
+    WBT.g_gui:Update();
+end
+resetopts = Test.ResetOpts

--- a/Test.lua
+++ b/Test.lua
@@ -114,11 +114,6 @@ local function SimNoShardKill(name, dt_expire, server)
     PutOrUpdateKillInfo_Advanced(name, dt_expire, "SHD", KillInfo.CURRENT_VERSION, shard_id);
 end
 
-local function SimNoShardKillRustfeather()
-    PutOrUpdateKillInfo_Advanced("Rustfeather", 25, "SHD", KillInfo.CURRENT_VERSION, KillInfo.UNKNOWN_SHARD);
-end
-dnoshard = SimNoShardKillRustfeather;
-
 local function SimKillSpecial(dt_expire)
     SimServerKill("Grellkin", dt_expire);
     SimOutdatedVersionKill("Grellkin", dt_expire);
@@ -141,27 +136,23 @@ end
 function Test.StartTimers300()
     SimKillEverything(300);
 end
-dsim300 = Test.StartTimers300; -- Lazy command for running from command line without access to macros.
 
 -- Starts timers 25 seconds before they expire. This gives time to check that
 -- alerts/sharing is performed.
 function Test.StartTimers25()
     SimKillEverything(25);
 end
-dsim25 = Test.StartTimers25;
 
 -- Starts timer 4 seconds before sharing. This allows to check what happens when
 -- timers expire.
 function Test.StartTimers4(n)
     SimKillEverything(4);
 end
-dsim4 = Test.StartTimers4;
 
 function Test.ShareLegacyTimer(shard_id_or_nil)
     local msg = TestUtil.CreateShareMsg("Grellkin", GetServerTime(), 9, shard_id_or_nil)
     SendChatMessage(msg, "SAY");
 end
-dshare = Test.ShareLegacyTimer;
 
 function Test.ResetOpts()
     for k, v in pairs(WBT.defaults.global) do
@@ -171,7 +162,6 @@ function Test.ResetOpts()
     end
     WBT.g_gui:Update();
 end
-resetopts = Test.ResetOpts;
 
 function Test.RestartShardDetection()
     local f = WBT.EventHandlerFrames.shard_detection_restarter_frame;
@@ -218,10 +208,10 @@ function Test:BuildTestGUI()
     self.grp.frame:SetFrameStrata("LOW");
     self.grp:SetLayout("Flow");
     self.grp:SetWidth(120);
-    self.grp:AddChild(self:CreateButton("dsim300",        dsim300));
-    self.grp:AddChild(self:CreateButton("dsim25",         dsim25));
-    self.grp:AddChild(self:CreateButton("dsim4",          dsim4));
-    self.grp:AddChild(self:CreateButton("Reset opts",     resetopts));
+    self.grp:AddChild(self:CreateButton("dsim300",        Test.StartTimers300));
+    self.grp:AddChild(self:CreateButton("dsim25",         Test.StartTimers25));
+    self.grp:AddChild(self:CreateButton("dsim4",          Test.StartTimers4));
+    self.grp:AddChild(self:CreateButton("Reset opts",     Test.ResetOpts));
     self.grp:AddChild(self:CreateButton("Reset",          WBT.ResetKillInfo));
     self.grp:AddChild(self:CreateButton("Set isle id 1",  Test.SetIsleOfGiantsSavedShardId_1));
     self.grp:AddChild(self:CreateButton("Set isle id 2",  Test.SetIsleOfGiantsSavedShardId_2));

--- a/Test.lua
+++ b/Test.lua
@@ -61,7 +61,7 @@ local TestUtil = WBT.TestUtil;
 local Test     = WBT.Test;
 
 local ShardIds = {
-    NON_SAVED_ZONE   = 0,  -- No saved zone should haev this ID.
+    NON_SAVED_ZONE   = 0,  -- No saved zone should have this ID.
     ISLE_OF_GIANTS_1 = 1,
     ISLE_OF_GIANTS_2 = 2,
 }

--- a/Test.lua
+++ b/Test.lua
@@ -175,4 +175,61 @@ function Test.ResetOpts()
     end
     WBT.g_gui:Update();
 end
-resetopts = Test.ResetOpts
+resetopts = Test.ResetOpts;
+
+function Test.RestartShardDetection()
+    local f = WBT.EventHandlerFrames.shard_detection_restarter_frame;
+    local delay_old = f.delay;
+    f.delay = 0;
+    f:Handler();
+    f.delay = delay_old;
+end
+
+function Test.ToggleDevSilent()
+    WBT.Options.dev_silent:Toggle();
+end
+
+function Test.PrintShards()
+    print("Current:", WBT.GetCurrentShardID());
+    print("Saved:", WBT.GetSavedShardID(WBT.GetCurrentMapId()));
+end
+
+--------------------------------------------------------------------------------
+
+function Test:CreateButton(text, fcn)
+    local btn = self.AceGUI:Create("Button");
+    btn:SetText(text);
+    btn:SetCallback("OnClick", fcn);
+    return btn;
+end
+
+function Test:BuildTestGUI()
+    if self.AceGUI == nil then
+        self.AceGUI = LibStub("AceGUI-3.0");
+    end
+
+    self.grp = self.AceGUI:Create("SimpleGroup");
+    self.grp.frame:SetFrameStrata("LOW");
+    self.grp:SetLayout("Flow");
+    self.grp:SetWidth(120);
+    self.grp:AddChild(self:CreateButton("dsim4",  dsim4));
+    self.grp:AddChild(self:CreateButton("dsim25", dsim25));
+    self.grp:AddChild(self:CreateButton("Reset opts", resetopts));
+    self.grp:AddChild(self:CreateButton("Reset", WBT.ResetKillInfo));
+    self.grp:AddChild(self:CreateButton("Restart shard", Test.RestartShardDetection));
+    self.grp:AddChild(self:CreateButton("Show shards", Test.PrintShards));
+    self.grp:AddChild(self:CreateButton("Silent +-", Test.ToggleDevSilent));
+
+    self.grp:AddChild(self:CreateButton("Reload", ReloadUI));
+    
+    self.grp:ClearAllPoints();
+    self.grp:SetPoint("TopLeft", nil, 100, -200);
+
+    self.grp.frame:Show();
+end
+
+hooksecurefunc(WBT.AceAddon, "OnEnable", function(...)
+    if WBT.db.global.build_test_gui then
+        Test:BuildTestGUI();
+    end
+end);

--- a/Test.lua
+++ b/Test.lua
@@ -11,11 +11,10 @@
 # Release tests:
 1. Perform all other tests.
 
-# Before push to master tests:
+# Before push to master:
 1. Unit tests must pass: UnitTests.lua
 2. For any changed module, perform relevant tests.
-3. Manually check that happy path and most edge cases work. If necessary also
-   write down a test for it here.
+3. Manually check that happy path and relevant edge cases work.
 
 #--------------------------------------------------------------------------------
 

--- a/TestUtil.lua
+++ b/TestUtil.lua
@@ -8,13 +8,16 @@ end
 
 function TestUtil.CreateShareMsg(bossname, servertime, t_since_death, shard_id)
     local t = servertime - t_since_death;
+    local decorator
     local shard_id_part
     if shard_id then
+        decorator = ""
         shard_id_part = "-" .. tostring(shard_id)
     else
+        decorator = "{rt8}"
         shard_id_part = ""  -- Legacy. Can't happen any longer.
     end
-    return "{rt8}"..bossname.."{rt8}: 6m 52s (WorldBossTimers:" .. tostring(t) .. shard_id_part .. ")";
+    return decorator..bossname..decorator..": 6m 52s (WorldBossTimers:" .. tostring(t) .. shard_id_part .. ")";
 end
 
 return TestUtil;

--- a/UnitTest.lua
+++ b/UnitTest.lua
@@ -15,7 +15,7 @@ local EventManager = {};
 EventManager.frames = {};
 
 function EventManager:Reset()
-    frames = {};
+    self.frames = {};
 end
 
 function EventManager:FireEvent(event, ...)
@@ -101,9 +101,6 @@ function LibStub(addonName)
     end
     function ls:New(dbName, defaultDb)
         return defaultDb;
-    end
-    function ls:Embed(...)
-        return;
     end
     function ls:AddToBlizOptions(...)
         return;
@@ -215,7 +212,7 @@ function C_Timer.After(_, fcn)
     fcn();
 end
 
-function PlaySoundFile()   return; end
+function PlaySoundFile(_, _)   return; end
 function FlashClientIcon() return; end
 function RequestRaidInfo() return; end
 
@@ -272,7 +269,7 @@ end
 local WBT;  -- Convenient to put it in this scope, in order to write helper fcns.
 
 function TestStrSplit()
-    a, b, c = strsplit("-", "a-b1-c22");
+    local a, b, c = strsplit("-", "a-b1-c22");
     assert(a == "a",   a);
     assert(b == "b1",  b);
     assert(c == "c22", c);
@@ -470,7 +467,7 @@ local function TestSavedShardKillInfo(bossname, expectSuccess)
     assert(ki);  -- Found again
 end
 
-function main()
+local function main()
     TestStrSplit();
     TestSharingWithoutShardId();
     TestShare("Oondasta",     true);

--- a/UnitTest.lua
+++ b/UnitTest.lua
@@ -135,6 +135,7 @@ function GUI.SetupAceGUI()       return; end
 function GUI.Init()              return; end
 function GUI:Update()            return; end
 function GUI:UpdateWindowTitle() return; end
+function GUI:Rebuild()           return; end
 
 
 --------------------------------------------------------------------------------
@@ -209,6 +210,25 @@ function C_Map.GetBestMapForUnit(_)
     return g_game.player.map_id;
 end
 
+C_Timer = {};
+function C_Timer.After(_, fcn)
+    fcn();
+end
+
+function PlaySoundFile()   return; end
+function FlashClientIcon() return; end
+function RequestRaidInfo() return; end
+
+
+-- Change this fields before firing an event that uses combat event info.
+local CombatEventInfo = {
+    eventType = "",
+    dest_unit_guid = "";
+}
+function CombatLogGetCurrentEventInfo()
+    local _ = nil;
+    return _, CombatEventInfo.eventType, _, _, _, _, _, CombatEventInfo.dest_unit_guid, _;
+end
 --------------------------------------------------------------------------------
 -- WoW lua API
 --------------------------------------------------------------------------------
@@ -249,6 +269,8 @@ end
 -- Tests
 --------------------------------------------------------------------------------
 
+local WBT;  -- Convenient to put it in this scope, in order to write helper fcns.
+
 function TestStrSplit()
     a, b, c = strsplit("-", "a-b1-c22");
     assert(a == "a",   a);
@@ -256,15 +278,31 @@ function TestStrSplit()
     assert(c == "c22", c);
 end
 
+local function BuildGUID(boss_name)
+    local npc_id = tostring(WBT.BossData.Get(boss_name).ids[1]);
+    local shard_id = tostring(g_game.world.shard_id);
+    return "Creature-2-3-4-"..shard_id.."-"..npc_id;
+end
+
 local function FireDetectShard()
     EventManager:FireEvent("UPDATE_MOUSEOVER_UNIT", "mouseover");
+end
+
+local function FireRestartShardDetection()
+    EventManager:FireEvent("ZONE_CHANGED_NEW_AREA");
+end
+
+local function FireLocalBossDeath()
+    CombatEventInfo.eventType = "UNIT_DIED";
+    CombatEventInfo.dest_unit_guid = BuildGUID(WBT.BossesInCurrentZone()[1].name);
+    EventManager:FireEvent("COMBAT_LOG_EVENT_UNFILTERED");
 end
 
 local function TestSharingWithoutShardId()
     g_test_settings.wbt_print = false;
     local bossname = "Oondasta";
     EventManager:Reset();
-    local WBT = LoadWBT();
+    WBT = LoadWBT();
     WBT.AceAddon:OnEnable();
 
     -- Detect current shard:
@@ -292,7 +330,7 @@ end
 
 local function TestShare(bossname, expectSuccess)
     EventManager:Reset();
-    local WBT = LoadWBT();
+    WBT = LoadWBT();
     WBT.AceAddon:OnEnable();
 
     -- Detect current shard:
@@ -314,6 +352,124 @@ local function TestShare(bossname, expectSuccess)
     assert(nTimers == nTimersExp, "Incorrect number of timers: " .. nTimers);
 end
 
+local function TestSavedShard(bossname, expectSuccess)
+    EventManager:Reset();
+    WBT = LoadWBT();
+    local KillInfo = WBT.KillInfo;
+    WBT.AceAddon:OnEnable();
+
+    -- Initially saved shard should be unknown:
+    assert(WBT.GetCurrentShardID()                    == KillInfo.UNKNOWN_SHARD);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == KillInfo.UNKNOWN_SHARD);
+
+    -- Detect initial shard:
+    g_game.world.shard_id = 44;
+    FireDetectShard();
+    assert(WBT.GetCurrentShardID()                    == g_game.world.shard_id);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
+
+    -- Reset current shard:
+    FireRestartShardDetection();
+    assert(WBT.GetCurrentShardID()                    == KillInfo.UNKNOWN_SHARD);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
+
+    -- Find same shard again:
+    FireDetectShard();
+    assert(WBT.GetCurrentShardID()                    == g_game.world.shard_id);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
+
+    -- Reset again:
+    FireRestartShardDetection();
+    assert(WBT.GetCurrentShardID()                    == KillInfo.UNKNOWN_SHARD);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
+
+    -- Find new shard:
+    g_game.world.shard_id = 55;
+    FireDetectShard();
+    assert(WBT.GetCurrentShardID()                    == g_game.world.shard_id);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
+
+    -- Reset once again:
+    FireRestartShardDetection();
+    assert(WBT.GetCurrentShardID()                    == KillInfo.UNKNOWN_SHARD);
+    assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
+end
+
+local function TestSavedShardKillInfo(bossname, expectSuccess)
+    EventManager:Reset();
+    WBT = LoadWBT();
+    local KillInfo = WBT.KillInfo;
+    local Options = WBT.Options;
+    WBT.AceAddon:OnEnable();
+    local ki;
+
+    -- Detect shard and kill boss:
+    g_game.world.shard_id = 44;
+    FireDetectShard();
+    FireLocalBossDeath();
+
+    Options.assume_realm_keeps_shard.set(true);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);
+    Options.assume_realm_keeps_shard.set(false);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);
+
+    -- Reset current shard:
+    FireRestartShardDetection();
+
+    Options.assume_realm_keeps_shard.set(true);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);
+    Options.assume_realm_keeps_shard.set(false);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki == nil);  -- Now nil
+
+    -- Find same shard again:
+    FireDetectShard();
+
+    Options.assume_realm_keeps_shard.set(true);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);
+    Options.assume_realm_keeps_shard.set(false);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);  -- Found again
+
+    -- Find new shard:
+    g_game.world.shard_id = 55;
+    FireRestartShardDetection();
+    FireDetectShard();
+
+    Options.assume_realm_keeps_shard.set(true);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki == nil);  -- Now also nil!
+    Options.assume_realm_keeps_shard.set(false);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki == nil);  -- Nil again
+
+    -- Reset the new shard:
+    FireRestartShardDetection();
+
+    Options.assume_realm_keeps_shard.set(true);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki == nil);  -- Still nil
+    Options.assume_realm_keeps_shard.set(false);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki == nil);  -- Still nil
+
+    -- Find old shard again:
+    g_game.world.shard_id = 44;
+    FireRestartShardDetection();
+    FireDetectShard();
+
+    Options.assume_realm_keeps_shard.set(true);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);  -- Found again
+    Options.assume_realm_keeps_shard.set(false);
+    ki = WBT.GetPrimaryKillInfo();
+    assert(ki);  -- Found again
+end
+
 function main()
     TestStrSplit();
     TestSharingWithoutShardId();
@@ -322,6 +478,8 @@ function main()
     TestShare("A. Harvester", true);
     TestShare("NotBoss",      false);
     TestShare("Sha of Rage",  false);
+    TestSavedShard();
+    TestSavedShardKillInfo();
 end
 
 main()

--- a/UnitTest.lua
+++ b/UnitTest.lua
@@ -349,7 +349,7 @@ local function TestShare(bossname, expectSuccess)
     assert(nTimers == nTimersExp, "Incorrect number of timers: " .. nTimers);
 end
 
-local function TestSavedShard(bossname, expectSuccess)
+local function TestSavedShard()
     EventManager:Reset();
     WBT = LoadWBT();
     local KillInfo = WBT.KillInfo;
@@ -392,10 +392,9 @@ local function TestSavedShard(bossname, expectSuccess)
     assert(WBT.GetSavedShardID(WBT.GetCurrentMapId()) == g_game.world.shard_id);
 end
 
-local function TestSavedShardKillInfo(bossname, expectSuccess)
+local function TestSavedShardKillInfo()
     EventManager:Reset();
     WBT = LoadWBT();
-    local KillInfo = WBT.KillInfo;
     local Options = WBT.Options;
     WBT.AceAddon:OnEnable();
     local ki;

--- a/UnitTest.lua
+++ b/UnitTest.lua
@@ -151,6 +151,7 @@ local g_game = {
         -- Static
         name = "Chainorth",
         realmname = "Stormreaver",
+        connected_realms = {"Stormreaver", "Vashj"},
         -- Dynamic
         map_id = 507,  -- Isle of Giants
         coords = {     -- Oondasta spawn point.
@@ -180,6 +181,10 @@ end
 
 function GetRealmName()
     return g_game.player.realm_name;
+end
+
+function GetAutoCompleteRealms()
+    return g_game.player.connected_realms;
 end
 
 -- XXX: Not correct, but doesn't matter right now.

--- a/Util.lua
+++ b/Util.lua
@@ -77,12 +77,18 @@ function Util.IsTable(obj)
     return type(obj) == "table";
 end
 
-function Util.SetContainsKey(set, key)
+--------------------------------------------------------------------------------
+-- SetUtil
+--------------------------------------------------------------------------------
+Util.SetUtil = {};
+local SetUtil = Util.SetUtil;
+
+function SetUtil.ContainsKey(set, key)
     return set[key] ~= nil;
 end
 
--- The WBT sets are small, so linear search is good enough.
-function Util.SetElementKey(set, value)
+function SetUtil.FindKey(set, value)
+    -- The WBT sets are small, so linear search is good enough.
     for k, v in pairs(set) do
         if v == value then
             return k;
@@ -91,9 +97,10 @@ function Util.SetElementKey(set, value)
     return nil;
 end
 
-function Util.SetContainsValue(set, value)
-    return Util.SetElementKey(set, value) and true;
+function SetUtil.ContainsValue(set, value)
+    return SetUtil.FindKey(set, value) and true;
 end
+--------------------------------------------------------------------------------
 
 function Util.FormatTimeSeconds(seconds)
     local mins = math.floor(seconds / 60);

--- a/Util.lua
+++ b/Util.lua
@@ -212,4 +212,15 @@ function Util.MultiKeyTable:GetAllSubVals(k)
     return subvals;
 end
 
+-- Always includes the original main realm.
+function Util.GetConnectedRealms()
+    local realms = GetAutoCompleteRealms();
+    if next(realms) == nil then
+        -- Empty table -> not a connected realm.
+        realms = { GetNormalizedRealmName() };
+    end
+
+    return realms;
+end
+
 return Util;

--- a/Util.lua
+++ b/Util.lua
@@ -81,8 +81,7 @@ function Util.SetContainsKey(set, key)
     return set[key] ~= nil;
 end
 
--- The sets contain very few values, so for now I won't implement
--- any better algorithms here.
+-- The WBT sets are small, so linear search is good enough.
 function Util.SetElementKey(set, value)
     for k, v in pairs(set) do
         if v == value then
@@ -94,15 +93,6 @@ end
 
 function Util.SetContainsValue(set, value)
     return Util.SetElementKey(set, value) and true;
-end
-
-function Util.RemoveFromSet(set, value)
-    local k = Util.SetElementKey(set, value);
-    if k then
-        table.remove(set, k, value);
-        return true;
-    end
-    return false;
 end
 
 function Util.FormatTimeSeconds(seconds)

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -36,6 +36,16 @@ WBT.AceAddon = LibStub("AceAddon-3.0"):NewAddon("WBT", "AceConsole-3.0");
 -- Workaround to keep the nice WBT:Print function.
 WBT.Print = function(self, text) WBT.AceAddon:Print(text) end
 
+
+-- Enum that describes why the GUI was requested to update.
+WBT.UpdateEvents = {};
+WBT.UpdateEvents.UNSPECIFIED    = 0;
+WBT.UpdateEvents.SHARD_DETECTED = 1;
+
+--------------------------------------------------------------------------------
+-- Logger
+--------------------------------------------------------------------------------
+
 -- Global logger. OK since WoW is single-threaded.
 WBT.Logger = {
     options_tbl = nil; -- Used to show options in GUI.
@@ -131,6 +141,8 @@ end
 function Logger.Info(...)
     Logger.Log(Logger.LogLevels.Info, ...);
 end
+
+--------------------------------------------------------------------------------
 
 local boss_death_frame;
 local boss_combat_frame;
@@ -640,8 +652,8 @@ local function StartShardDetectionHandler()
         if unit_type == "Creature" or unit_type == "Vehicle" then
             g_current_shard_id = WBT.ParseShardID(guid);
             WBT.PutSavedShardID(g_current_shard_id);
-            g_gui:Update();
             Logger.Debug("[ShardDetection]: New shard ID detected:", g_current_shard_id);
+            g_gui:Update(WBT.UpdateEvents.SHARD_DETECTED);
             self:UnregisterEvents();
         end
     end);

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -174,7 +174,7 @@ WBT.defaults = {
         multi_realm = false,
         show_boss_zone_only = false,
         cyclic = false,
-        highlight = false,  -- XXX: Should be changed to true
+        highlight = false,
         show_saved = false,
         show_realm = false,
         dev_silent = false,
@@ -850,7 +850,7 @@ function WBT.AceAddon:OnEnable()
         Com.LeaveRequestMode();
     end
     -- Note that Com is currently not used, since it only works for
-    -- connected realms...
+    -- connected realms.
     Com:RegisterComm(Com.PREF_SR, Com.OnCommReceivedSR);
     Com:RegisterComm(Com.PREF_RR, Com.OnCommReceivedRR);
 

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -185,7 +185,6 @@ WBT.defaults = {
 --------------------------------------------------------------------------------
 -- ConnectedRealmsData
 --------------------------------------------------------------------------------
-
 local ConnectedRealmsData = {};
 
 -- Data about the connected realms that needs to be saved to DB.
@@ -198,7 +197,6 @@ end
 function WBT.GetRealmKey()
     return table.concat(Util.GetConnectedRealms(), "_");
 end
-
 --------------------------------------------------------------------------------
 
 function WBT.IsUnknownShard(shard_id)
@@ -253,7 +251,7 @@ function WBT.HasKillInfoExpired(ki_id)
 end
 
 function WBT.IsBoss(name)
-    return Util.SetContainsKey(BossData.GetAll(), name);
+    return Util.SetUtil.ContainsKey(BossData.GetAll(), name);
 end
 
 -- Warning: This can different result, at least during addon loading / player enter world events.
@@ -687,7 +685,7 @@ local function StartChatParser()
             function(self, event, msg, sender)
                 if event == "CHAT_MSG_SAY" 
                         and msg == CHAT_MESSAGE_TIMER_REQUEST
-                        and not Util.SetContainsKey(answered_requesters, sender)
+                        and not Util.SetUtil.ContainsKey(answered_requesters, sender)
                         and not PlayerSentMessage(sender) then
 
                     if WBT.InBossZone() then

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -6,12 +6,6 @@
 local _, WBT = ...;
 WBT.addon_name = "WorldBossTimers";
 
---@do-not-package@
-wbt = WBT;
---@end-do-not-package@
-
-WBT.Dev = {};
-
 local KillInfo = WBT.KillInfo;
 local BossData = WBT.BossData;
 local Options  = WBT.Options;
@@ -19,7 +13,6 @@ local Sound    = WBT.Sound;
 local Util     = WBT.Util;
 local GUI      = WBT.GUI;
 local Com      = WBT.Com;
-local Dev      = WBT.Dev;
 
 -- Functions that will be created during startup.
 WBT.Functions = {
@@ -893,6 +886,11 @@ end
 --------------------------------------------------------------------------------
 -- Dev
 --------------------------------------------------------------------------------
+
+WBT = WBT;  -- Make global when developing
+
+WBT.Dev = {};
+local Dev = WBT.Dev;
 
 function Dev.PrintError(...)
     local text = "";

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -182,7 +182,12 @@ end
 
 function WBT.GetCurrentShardID()
     -- Getter for access via other modules.
-    return g_current_shard_id;
+    return g_current_shard_id or KillInfo.UNKNOWN_SHARD;
+end
+
+function WBT.IsUnknownShard(shard_id)
+    -- Getter for access via other modules.
+    return shard_id == nil or shard_id == KillInfo.UNKNOWN_SHARD;
 end
 
 function WBT.ParseShardID(unit_guid)
@@ -425,7 +430,7 @@ local function GetSafeSpawnAnnouncerWithCooldown()
         local announced = false;
         local t_now = GetServerTime();
 
-        if WBT.GetCurrentShardID() == nil then
+        if WBT.IsUnknownShard(WBT.GetCurrentShardID()) then
             Logger.Info("Can't share timers when the shard ID is unknown. Mouse over an NPC to detect it.");
             return announced;
         end
@@ -599,7 +604,7 @@ local function StartShardDetectionHandler()
         local unit_type = strsplit("-", guid);
         if unit_type == "Creature" or unit_type == "Vehicle" then
             g_current_shard_id = WBT.ParseShardID(guid);
-            g_gui:UpdateWindowTitle();
+            g_gui:Update();
             Logger.Debug("[ShardDetection]: New shard ID detected:", g_current_shard_id);
             self:UnregisterEvents();
         end
@@ -611,7 +616,7 @@ local function StartShardDetectionHandler()
     f_restart:RegisterEvent("SCENARIO_UPDATE");  -- Seems to fire when you swap shard due to joining a group.
     f_restart:SetScript("OnEvent", function(...)
         g_current_shard_id = nil;
-        g_gui:UpdateWindowTitle();
+        g_gui:Update();
         Logger.Debug("[ShardDetection]: Possibly shard change. Shard ID invalidated.");
 
         -- Wait a while before starting to detect the new shard. When phasing to a new shard it will still

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -237,7 +237,7 @@ function WBT.PutSavedShardIDForZone(zone_id, shard_id)
 end
 
 function WBT.PutSavedShardID(shard_id)
-    WBT.PutSavedShardID(WBT.GetCurrentMapId(), shard_id)
+    WBT.PutSavedShardIDForZone(WBT.GetCurrentMapId(), shard_id)
 end
 
 function WBT.ParseShardID(unit_guid)

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -174,7 +174,7 @@ WBT.defaults = {
         multi_realm = false,
         show_boss_zone_only = false,
         cyclic = false,
-        highlight = false,  -- TODO: Change to true
+        highlight = false,  -- XXX: Should be changed to true
         show_saved = false,
         show_realm = false,
         dev_silent = false,
@@ -188,16 +188,6 @@ WBT.defaults = {
         boss = {},
     },
 };
-
-function WBT:PrintError(...)
-    local text = "";
-    for n=1, select('#', ...) do
-      text = text .. " " .. select(n, ...);
-    end
-    text = Util.strtrim(text);
-    text = Util.ColoredString(Util.COLOR_RED, text);
-    WBT:Print(text);
-end
 
 --------------------------------------------------------------------------------
 -- ConnectedRealmsData
@@ -237,13 +227,17 @@ function WBT.GetSavedShardID(zone_id)
     return shard_id or KillInfo.UNKNOWN_SHARD;
 end
 
-function WBT.PutSavedShardID(shard_id)
+function WBT.PutSavedShardIDForZone(zone_id, shard_id)
     local crd = WBT.db.global.connected_realms_data[WBT.GetRealmKey()];
     if crd == nil then 
         crd = ConnectedRealmsData:New();
         WBT.db.global.connected_realms_data[WBT.GetRealmKey()] = crd;
     end
-    crd.shard_id_per_zone[WBT.GetCurrentMapId()] = shard_id;
+    crd.shard_id_per_zone[zone_id] = shard_id;
+end
+
+function WBT.PutSavedShardID(shard_id)
+    WBT.PutSavedShardID(WBT.GetCurrentMapId(), shard_id)
 end
 
 function WBT.ParseShardID(unit_guid)
@@ -896,6 +890,20 @@ end
 
 --@do-not-package@
 
+--------------------------------------------------------------------------------
+-- Dev
+--------------------------------------------------------------------------------
+
+function Dev.PrintError(...)
+    local text = "";
+    for n=1, select('#', ...) do
+      text = text .. " " .. select(n, ...);
+    end
+    text = Util.strtrim(text);
+    text = Util.ColoredString(Util.COLOR_RED, text);
+    WBT:Print(text);
+end
+
 -- Run this when standing at boss location to get a dump of what needs to be put
 -- in BossData.
 function Dev.PrettyPrintLocation()
@@ -918,15 +926,15 @@ end
 -- BossData.
 function Dev.PrintPlayerDistanceToBoss(boss_name)
     if not boss_name then
-        WBT:PrintError("Invalid argument: nil");
+        Dev.PrintError("Invalid argument: nil");
         return;
     end
     if not WBT.IsBoss(boss_name) then
-        WBT:PrintError("Invalid argument. Not a boss: " .. boss_name);
+        Dev.PrintError("Invalid argument. Not a boss: " .. boss_name);
         return;
     end
     if not WBT.IsInZoneOfBoss(boss_name) then
-        WBT:PrintError("Not in correct zone for " .. boss_name);
+        Dev.PrintError("Not in correct zone for " .. boss_name);
         return;
     end
     print(WBT.PlayerDistanceToBoss(boss_name));
@@ -946,6 +954,8 @@ end
 function Dev.StopGUI()
     WBT.kill_info_manager:SetScript("OnUpdate", nil);
 end
+
+--------------------------------------------------------------------------------
 
 --@end-do-not-package@
 

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -416,16 +416,6 @@ function WBT.GetColoredBossName(name)
 end
 local GetColoredBossName = WBT.GetColoredBossName;
 
-local function RegisterEvents()
-    WBT.EventHandlerFrames.boss_death_frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
-    WBT.EventHandlerFrames.boss_combat_frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
-end
-
-local function UnregisterEvents()
-    WBT.EventHandlerFrames.boss_death_frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
-    WBT.EventHandlerFrames.boss_combat_frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
-end
-
 -- Intended to be called from clicking an interactive label.
 function WBT.ResetBoss(ki_id)
     local kill_info = g_kill_infos[ki_id];
@@ -532,6 +522,7 @@ local function StartDeathTrackerFrame()
     local boss_death_frame = CreateFrame("Frame", "WBT_BOSS_DEATH_FRAME");
     WBT.EventHandlerFrames.boss_death_frame = boss_death_frame;
 
+    boss_death_frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
     boss_death_frame:SetScript("OnEvent", function(...)
             local _, eventType, _, _, _, _, _, dest_unit_guid, _ = CombatLogGetCurrentEventInfo();
 
@@ -592,6 +583,7 @@ local function StartCombatScannerFrame()
         end
     end
 
+    boss_combat_frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
     boss_combat_frame:SetScript("OnEvent", ScanWorldBossCombat);
 end
 
@@ -897,10 +889,6 @@ function WBT.AceAddon:OnEnable()
 
     self:RegisterChatCommand("wbt", Options.SlashHandler);
     self:RegisterChatCommand("worldbosstimers", Options.SlashHandler);
-
-
-    RegisterEvents(); -- TODO: Update when this and unreg is called!
-    -- UnregisterEvents();
 end
 
 function WBT.AceAddon:OnDisable()

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -164,6 +164,7 @@ WBT.defaults = {
         -- Options:
         lock = false,
         sound_enabled = true,
+        assume_realm_keeps_shard = true,
         multi_realm = false,
         show_boss_zone_only = false,
         cyclic = false,

--- a/WorldBossTimers.toc
+++ b/WorldBossTimers.toc
@@ -1,4 +1,4 @@
-## Interface: 100005
+## Interface: 100100
 ## Title: WorldBossTimers
 ## Notes: Creates timers for world bosses
 ## Author: Soulstorm

--- a/WorldBossTimers.toc
+++ b/WorldBossTimers.toc
@@ -4,6 +4,7 @@
 ## Author: Soulstorm
 ## Version: v1.11
 ## SavedVariables: WorldBossTimersDB
+## IconTexture: 656169
 
 embeds.xml
 


### PR DESCRIPTION
Adds an option, default true, which assumes that when the current shard is unknown, the previous known shard for the zone is the current shard.

- Shard IDS are saved per realm and zone
- Timers on the latest known shards on the realm are always shown, also for zones other than current
- Timers still can't be shared unless the current shard is known
- Gives [Info] message if a fresh timer (i.e. a boss about to spawn on current assumed shard) is proven to be invalid, since the player is actually on another shard

Also adds improvements to the devcontainer.

Fixes #95 Fixes #96