### PR TITLE
Increase time window when alert can play and clean up

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -152,7 +152,7 @@ function GUI:CreateNewLabel(guid, kill_info)
             gui:Update();
         end);
     label.userdata.t_death = kill_info.t_death;
-    label.userdata.time_next_spawn = kill_info:GetSpawnTimeSec();
+    label.userdata.time_next_spawn = kill_info:GetSecondsUntilLatestRespawn();
     return label;
 end
 
@@ -264,7 +264,7 @@ end
 -- True when the timer for a cyclic label restarted (i.e. made a lap).
 -- This includes the event that a kill info goes from non-expired to expired.
 function GUI.CyclicKillInfoRestarted(kill_info, label)
-    local t_next_spawn = kill_info:GetSpawnTimeSec();
+    local t_next_spawn = kill_info:GetSecondsUntilLatestRespawn();
     if label.userdata.time_next_spawn < t_next_spawn then
         label.userdata.time_next_spawn = t_next_spawn;
         return true;

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -30,16 +30,13 @@ function KillInfo.CompareTo(t, a, b)
     local k1 = t[a];
     local k2 = t[b];
 
-    k1:Update();
-    k2:Update();
-
     if k1:IsExpired() and not k2:IsExpired() then
         return false;
     elseif not k1:IsExpired() and k2:IsExpired() then
         return true;
     end
 
-    return k1:GetSpawnTimeSec() < k2:GetSpawnTimeSec();
+    return k1:GetSecondsUntilLatestRespawn() < k2:GetSecondsUntilLatestRespawn();
 end
 
 function KillInfo.IsValidID(id)
@@ -83,9 +80,7 @@ function KillInfo:HasShardID()
     return self.shard_id ~= nil;
 end
 
--- A KillInfo is no longer valid if its data was recorded before
--- the KillInfo class was introduced.
--- The field self.until_time did not exist then.
+-- Needed in order to verify that all fields are present.
 function KillInfo:IsValidVersion()
     return self.version and self.version == KillInfo.CURRENT_VERSION;
 end
@@ -118,16 +113,11 @@ function KillInfo:Print(indent)
 end
 
 function KillInfo:SetNewDeath(t_death)
-    -- FIXME: It doesn't make sense to this function from here. I think it's
+    -- FIXME: It doesn't make sense to call this function from here. I think it's
     -- a remnant from the time when the addon tried to upgrade KillInfos.
     self:SetInitialValues();
 
-    -- NOTE: self.t_death is later updated when the kill_info has expired.
-    -- self.until_time is (currently) never updated though.
     self.t_death = t_death;
-    self.until_time = self.t_death + self.db.max_respawn;
-
-    return self.until_time < GetServerTime();
 end
 
 function KillInfo:New(boss_name, t_death, shard_id)
@@ -190,55 +180,61 @@ function KillInfo:GetServerDeathTime()
     return self.t_death;
 end
 
-function KillInfo:GetTimeSinceDeath()
+function KillInfo:GetSecondsSinceDeath()
     return GetServerTime() - self.t_death;
 end
 
-function KillInfo:GetSpawnTimesSecRandom()
-    local t_since_death = self:GetTimeSinceDeath();
-    local t_lower_bound = self.db.min_respawn - t_since_death;
-    local t_upper_bound = self.db.max_respawn - t_since_death;
-
-    return t_lower_bound, t_upper_bound;
+function KillInfo:GetEarliestRespawnTimePoint()
+    return self.t_death + self.db.min_respawn;
 end
 
-function KillInfo:GetSpawnTimeSec()
-    if self:HasRandomSpawnTime() then
-        local _, t_upper = self:GetSpawnTimesSecRandom();
-        return t_upper;
-    else
-        return self.db.min_respawn - self:GetTimeSinceDeath();
+function KillInfo:GetLatestRespawnTimePoint()
+    return self.t_death + self.db.max_respawn;
+end
+
+function KillInfo:GetSecondsUntilEarliestRespawn(opt_cyclic)
+    local t = self:GetEarliestRespawnTimePoint() - GetServerTime();
+    if opt_cyclic then
+        while t < 0 do
+            t = t + self.db.max_respawn;
+        end
     end
+    return t;
+end
+
+function KillInfo:GetSecondsUntilLatestRespawn(opt_cyclic)
+    local t = self:GetLatestRespawnTimePoint() - GetServerTime();
+    if opt_cyclic then
+        while t < 0 do
+            t = t + self.db.max_respawn;
+        end
+    end
+    return t;
 end
 
 function KillInfo:GetSpawnTimeAsText()
-    local outdated =  "--outdated--";
     if not self:IsValidVersion() then
-        return outdated;
+        return "--outdated--";
     end
 
     if self:HasRandomSpawnTime() then
-        local t_lower, t_upper = self:GetSpawnTimesSecRandom();
+        local t_lower = self:GetSecondsUntilEarliestRespawn(true);
+        local t_upper = self:GetSecondsUntilLatestRespawn(true);
         if t_lower == nil or t_upper == nil then
-            return outdated;
-        elseif t_lower < 0 then
+            return "--invalid1--";
+        elseif t_lower > t_upper then
             return "0s" .. RANDOM_DELIM .. Util.FormatTimeSeconds(t_upper)
         else
             return Util.FormatTimeSeconds(t_lower) .. RANDOM_DELIM .. Util.FormatTimeSeconds(t_upper)
         end
     else
-        local spawn_time_sec = self:GetSpawnTimeSec();
-        if spawn_time_sec == nil or spawn_time_sec < 0 then
-            return outdated;
-        end
-
-        return Util.FormatTimeSeconds(spawn_time_sec);
+        return Util.FormatTimeSeconds(self:GetSecondsUntilEarliestRespawn(true));
     end
 end
 
 function KillInfo:ShouldAutoAnnounce()
     return WBT.db.global.auto_announce
-            and Util.SetUtil.ContainsValue(self.announce_times, self.remaining_time)
+            and Util.SetUtil.ContainsValue(self.announce_times, self:GetSecondsUntilLatestRespawn())
             and WBT.PlayerIsInBossPerimiter(self.boss_name)
             and WBT.BossData.Get(self.boss_name).auto_announce
             and self:IsSafeToShare({});
@@ -250,9 +246,9 @@ function KillInfo:InTimeWindow(from, to)
 end
 
 function KillInfo:ShouldRespawnAlertPlayNow(offset)
-    local t_now = GetServerTime();
-    local until_time_offset = self.until_time - offset;
-    local trigger = self:InTimeWindow(until_time_offset, until_time_offset + 1)
+    local t_before_respawn = self:GetLatestRespawnTimePoint() - offset;
+
+    local trigger = self:InTimeWindow(t_before_respawn, t_before_respawn + 1)
             and WBT.InZoneAndShardForTimer(self)
             and WBT.PlayerIsInBossPerimiter(self.boss_name)
             and self:IsValidVersion()
@@ -265,24 +261,8 @@ function KillInfo:ShouldRespawnAlertPlayNow(offset)
     return trigger;
 end
 
-function KillInfo:Update()
-    self.remaining_time = self.until_time - GetServerTime();
-end
-
-function KillInfo:EstimationNextSpawn()
-    local t_spawn = self.t_death;
-    local t_now = GetServerTime();
-    local max_respawn = self.db.max_respawn;
-    while t_spawn < t_now do
-        t_spawn = t_spawn + max_respawn;
-    end
-
-    local t_death_new = t_spawn - max_respawn;
-    return t_death_new, t_spawn;
-end
-
 function KillInfo:IsExpired()
-    return self.until_time < GetServerTime();
+    return self:GetSecondsUntilLatestRespawn() < 0;
 end
 
 function KillInfo:HasUnknownShard()

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -248,7 +248,7 @@ end
 function KillInfo:ShouldRespawnAlertPlayNow(offset)
     local t_before_respawn = self:GetLatestRespawnTimePoint() - offset;
 
-    local trigger = self:InTimeWindow(t_before_respawn, t_before_respawn + 1)
+    local trigger = self:InTimeWindow(t_before_respawn, t_before_respawn + 2)
             and WBT.InZoneAndShardForTimer(self)
             and WBT.PlayerIsInBossPerimiter(self.boss_name)
             and self:IsValidVersion()

--- a/Test.lua
+++ b/Test.lua
@@ -194,6 +194,21 @@ function Test.PrintShards()
     print("Saved:", WBT.GetSavedShardID(WBT.GetCurrentMapId()));
 end
 
+function Test.IncreaseAllTimerAges(sec)
+    for _, ki in pairs(WBT.db.global.kill_infos) do
+        ki.t_death = ki.t_death - sec;
+    end
+    WBT.GUI:Update();
+end
+
+function Test.AgeTimersOneMin()
+    Test.IncreaseAllTimerAges(60);
+end
+
+function Test.AgeTimersTenMin()
+    Test.IncreaseAllTimerAges(10*60);
+end
+
 --------------------------------------------------------------------------------
 
 function Test:CreateButton(text, fcn)
@@ -215,6 +230,8 @@ function Test:BuildTestGUI()
     self.grp:AddChild(self:CreateButton("dsim300",        Test.StartTimers300));
     self.grp:AddChild(self:CreateButton("dsim25",         Test.StartTimers25));
     self.grp:AddChild(self:CreateButton("dsim4",          Test.StartTimers4));
+    self.grp:AddChild(self:CreateButton("Age 1",          Test.AgeTimersOneMin));
+    self.grp:AddChild(self:CreateButton("Age 10",         Test.AgeTimersTenMin));
     self.grp:AddChild(self:CreateButton("Reset",          WBT.ResetKillInfo));
     self.grp:AddChild(self:CreateButton("Set isle id 1",  Test.SetIsleOfGiantsSavedShardId_1));
     self.grp:AddChild(self:CreateButton("Set isle id 2",  Test.SetIsleOfGiantsSavedShardId_2));

--- a/Test.lua
+++ b/Test.lua
@@ -30,7 +30,7 @@
 2. After (1.):
       a. /reload and check that everything looks OK.
       b. Relog and check that everything looks OK.
-3. Spam all buttons exploratorily. Check that nothing breaks.
+3. Click all buttons exploratorily. Check that nothing breaks.
 
 # Backend tests
 1. Run StartTimers25. Check that GUI behaves as expected. 

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -802,8 +802,6 @@ local function StartKillInfoManager()
             self.since_update = self.since_update + elapsed;
             if (self.since_update > t_update) then
                 for _, kill_info in pairs(g_kill_infos) do
-                    kill_info:Update();
-
                     if kill_info:ShouldAutoAnnounce() then
                         -- WBT.AnnounceSpawnTime(kill_info, true); DISABLED: broken in 8.2.5
                         -- TODO: Consider if here should be something else
@@ -812,12 +810,6 @@ local function StartKillInfoManager()
                     if kill_info:ShouldRespawnAlertPlayNow(Options.spawn_alert_sec_before.get()) then
                         FlashClientIcon();
                         PlaySoundAlertSpawn();
-                    end
-
-                    if kill_info:IsExpired() and Options.cyclic.get() then
-                        local t_death_new, t_spawn = kill_info:EstimationNextSpawn();
-                        kill_info.t_death = t_death_new
-                        self.until_time = t_spawn;
                     end
                 end
 


### PR DESCRIPTION
Increases time window from 1 sec to 2 sec. I don't expect it to have any effect, but doesn't hurt. Could possible help if update rate (1 per sec) doesn't match well will GetServerTime().

Also cleaned up code related to respawn times.