### PR TITLE
Avoid Lua error due to Blizzard bug

### DIFF
--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -222,6 +222,7 @@ function WBT.GetSavedShardID(zone_id)
 end
 
 function WBT.PutSavedShardIDForZone(zone_id, shard_id)
+    if not zone_id then return end
     local crd = WBT.db.global.connected_realms_data[WBT.GetRealmKey()];
     if crd == nil then 
         crd = ConnectedRealmsData:New();


### PR DESCRIPTION
If you enter the portal room off of Valdrakken (named Millenia's Threshold), the room does not have a correct map ID:

![image](https://github.com/fstenstrom/world-boss-timers/assets/458727/eab29d19-bf3a-409d-aea8-f9b6e755cde8)

This is a Blizzard error, obviously, but it results in a Lua error in WBT if you mouse over any NPCs in that room:

```
248x WorldBossTimers/WorldBossTimers.lua:230: table index is nil
[string "@WorldBossTimers/WorldBossTimers.lua"]:230: in function `PutSavedShardIDForZone'
[string "@WorldBossTimers/WorldBossTimers.lua"]:234: in function `PutSavedShardID'
[string "@WorldBossTimers/WorldBossTimers.lua"]:634: in function <WorldBossTimers/WorldBossTimers.lua:622>
```

To silence the Lua error, you can bail out at the start of the function `WBT.PutSavedShardIDForZone` if the zone_id is invalid. This should have no impact when Blizz fixes the error and gives the room a proper mapID.
