### PR TITLE
Disable combat scanning in non-boss zones, and improve combat handler performance

### DIFF
--- a/BossData.lua
+++ b/BossData.lua
@@ -546,7 +546,7 @@ function BossData.GetFromUnitGuid(guid, map_id)
     return nil;
 end
 
-function BossData.NameFromUnitGuid(guid, map_id)
+function BossData.BossNameFromUnitGuid(guid, map_id)
     local data = BossData.GetFromUnitGuid(guid, map_id);
     if data then
         return data.name;

--- a/KillInfo.lua
+++ b/KillInfo.lua
@@ -234,14 +234,6 @@ function KillInfo:GetSpawnTimeAsText()
     end
 end
 
-function KillInfo:ShouldAutoAnnounce()
-    return WBT.db.global.auto_announce
-            and Util.SetUtil.ContainsValue(self.announce_times, self:GetSecondsUntilLatestRespawn())
-            and WBT.PlayerIsInBossPerimiter(self.boss_name)
-            and WBT.BossData.Get(self.boss_name).auto_announce
-            and self:IsSafeToShare({});
-end
-
 function KillInfo:InTimeWindow(from, to)
     local t_now = GetServerTime();
     return from <= t_now and t_now <= to;

--- a/UnitTest.lua
+++ b/UnitTest.lua
@@ -263,6 +263,10 @@ local function LoadWBT()
     assert(loadfile("Options.lua"))         (addonName, addonTable);
     assert(loadfile("KillInfo.lua"))        (addonName, addonTable);
     local WBT = assert(loadfile("WorldBossTimers.lua"))(addonName, addonTable);
+
+    WBT.AceAddon:OnEnable();
+    EventManager:FireEvent("PLAYER_ENTERING_WORLD");
+
     return WBT;
 end
 
@@ -304,7 +308,6 @@ local function TestSharingWithoutShardId()
     local bossname = "Oondasta";
     EventManager:Reset();
     WBT = LoadWBT();
-    WBT.AceAddon:OnEnable();
 
     -- Detect current shard:
     local test_shard_id = 44;
@@ -332,7 +335,6 @@ end
 local function TestShare(bossname, expectSuccess)
     EventManager:Reset();
     WBT = LoadWBT();
-    WBT.AceAddon:OnEnable();
 
     -- Detect current shard:
     g_game.world.shard_id = 44;
@@ -356,7 +358,6 @@ end
 local function TestShareReceiverHasExpiredTimer()
     EventManager:Reset();
     WBT = LoadWBT();
-    WBT.AceAddon:OnEnable();
 
     -- Detect current shard:
     g_game.world.shard_id = 44;
@@ -395,7 +396,6 @@ local function TestSavedShard()
     EventManager:Reset();
     WBT = LoadWBT();
     local KillInfo = WBT.KillInfo;
-    WBT.AceAddon:OnEnable();
 
     -- Initially saved shard should be unknown:
     assert(WBT.GetCurrentShardID()                    == KillInfo.UNKNOWN_SHARD);
@@ -438,7 +438,6 @@ local function TestSavedShardKillInfo()
     EventManager:Reset();
     WBT = LoadWBT();
     local Options = WBT.Options;
-    WBT.AceAddon:OnEnable();
     local ki;
 
     -- Detect shard and kill boss:

--- a/Util.lua
+++ b/Util.lua
@@ -98,6 +98,16 @@ end
 function SetUtil.ContainsValue(set, value)
     return SetUtil.FindKey(set, value) and true;
 end
+
+--------------------------------------------------------------------------------
+-- String utils
+--------------------------------------------------------------------------------
+
+-- Source: http://lua-users.org/wiki/StringRecipes
+function Util.StrEndsWith(str, ending)
+    return ending == "" or str:sub(-#ending) == ending;
+end
+
 --------------------------------------------------------------------------------
 
 function Util.FormatTimeSeconds(seconds)

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -530,7 +530,8 @@ local function StartCombatHandler()
     local combat_frame = CreateFrame("Frame", "WBT_COMBAT_FRAME");
     WBT.EventHandlerFrames.combat_frame = combat_frame;
 
-    local time_out = 60*2; -- Old expansion world bosses SHOULD die in this time.
+    local time_out_combat = 60*2; -- Old expansion world bosses SHOULD die in this time
+    local time_out_death  = 30;   -- No debuff from the bosses should last longer than this
     combat_frame.t_next_alert_boss_combat = 0;
 
     function CombatHandler(...)
@@ -549,7 +550,7 @@ local function StartCombatHandler()
             WBT:Print(GetColoredBossName(name) .. " is now engaged in combat!");
             PlaySoundAlertBossCombat(name);
             FlashClientIcon();
-            combat_frame.t_next_alert_boss_combat = t + time_out;
+            combat_frame.t_next_alert_boss_combat = t + time_out_combat;
         end
         
         -- Check for boss death
@@ -558,6 +559,7 @@ local function StartCombatHandler()
             WBT.PutOrUpdateKillInfo(name, shard_id, GetServerTime());
             RequestRaidInfo(); -- Updates which bosses are saved
             g_gui:Update();
+            combat_frame.t_next_alert_boss_combat = t + time_out_death;
         end
     end
 

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -729,7 +729,6 @@ local function StartChatParser()
         );
     end
 
-    InitRequestParser();
     InitSharedTimersParser();
 end
 

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -530,7 +530,7 @@ local function StartCombatHandler()
     local combat_frame = CreateFrame("Frame", "WBT_COMBAT_FRAME");
     WBT.EventHandlerFrames.combat_frame = combat_frame;
 
-    local time_out_combat = 60*2; -- Old expansion world bosses SHOULD die in this time
+    local time_out_combat = 60*2; -- Old expansion world bosses should die in this time
     local time_out_death  = 30;   -- No debuff from the bosses should last longer than this
     combat_frame.t_next_alert_boss_combat = 0;
 
@@ -545,8 +545,8 @@ local function StartCombatHandler()
             return;
         end
 
-        -- Convert to English name from GUID, to make it work for
-        -- localization.
+        -- Find the English name from GUID, to make it work for localization, instead
+        -- of using the name in the event args.
         local name = BossData.BossNameFromUnitGuid(dest_unit_guid, WBT.GetCurrentMapId());
         if name == nil then
             return;

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -782,12 +782,8 @@ local function StartKillInfoManager()
     WBT.kill_info_manager:SetScript("OnUpdate", function(self, elapsed)
             self.since_update = self.since_update + elapsed;
             if (self.since_update > t_update) then
-                for _, kill_info in pairs(g_kill_infos) do
-                    if kill_info:ShouldAutoAnnounce() then
-                        -- WBT.AnnounceSpawnTime(kill_info, true); DISABLED: broken in 8.2.5
-                        -- TODO: Consider if here should be something else
-                    end
 
+                for _, kill_info in pairs(g_kill_infos) do
                     if kill_info:ShouldRespawnAlertPlayNow(Options.spawn_alert_sec_before.get()) then
                         FlashClientIcon();
                         PlaySoundAlertSpawn();

--- a/WorldBossTimers.lua
+++ b/WorldBossTimers.lua
@@ -136,7 +136,6 @@ end
 WBT.EventHandlerFrames = {
     boss_death_frame                = nil,
     boss_combat_frame               = nil,
-    request_parser                  = nil,
     timer_parser                    = nil,
     shard_detection_frame           = nil,
     shard_detection_restarter_frame = nil,
@@ -683,32 +682,6 @@ local function StartChatParser()
     local function PlayerSentMessage(sender)
         -- Since \b and alike doesnt exist: use "frontier pattern": %f[%A]
         return string.match(sender, GetUnitName("player") .. "%f[%A]") ~= nil;
-    end
-
-    local function InitRequestParser()
-        local request_parser = CreateFrame("Frame", "WBT_REQUEST_PARSER_FRAME");
-        WBT.EventHandlerFrames.request_parser = request_parser;
-        local answered_requesters = {};
-        request_parser:RegisterEvent("CHAT_MSG_SAY");
-        request_parser:SetScript("OnEvent",
-            function(self, event, msg, sender)
-                if event == "CHAT_MSG_SAY" 
-                        and msg == CHAT_MESSAGE_TIMER_REQUEST
-                        and not Util.SetUtil.ContainsKey(answered_requesters, sender)
-                        and not PlayerSentMessage(sender) then
-
-                    if WBT.InBossZone() then
-                        local ki = WBT.GetPrimaryKillInfo();
-                        if ki and ki:IsSafeToShare({}) then
-                            -- WBT.AnnounceSpawnTime(kill_info, true); DISABLED: broken by 8.2.5
-                            -- TODO: Consider if this could trigger some optional sparkle
-                            -- in the GUI instead
-                            answered_requesters[sender] = sender;
-                        end
-                    end
-                end
-            end
-        );
     end
 
     local function InitSharedTimersParser()


### PR DESCRIPTION
Fixes #115

The boss-in-combat and boss-died event handlers have been merged to a single event handler. This handler is now only called in boss zones.

---

I also looked into what could be the costly part of the call.

`CombatLogGetCurrentEventInfo()`: ~0.002 ms

`WBT.GetCurrentMapId()`: ~0.01 ms

`BossData.BossNameFromUnitGuid(...)`: ~0.07 ms. The `strsplit(...)` and `tostring()` seems to take about half of the time, and the loop iteration itself the other half.

Possible improvements:

1. Cache `WBT.GetCurrentMapId()` on event `"ZONE_CHANGED_NEW_AREA"`
2. Sort `BossData.tracked_bosses` on startup and binary search instead of linear search
3. Return early unless a relevant subevent (e.g. `"SPELL_DAMAGE"`)

Improvement (3.) is implemented in this fix.