### PR TITLE
Don't crash when unsupported rares (via patched BossData.lua) are deserialized

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,8 @@
         "ReloadUI",
         "IsControlKeyDown",
         "IsShiftKeyDown",
-        "DEFAULT_CHAT_FRAME"
+        "DEFAULT_CHAT_FRAME",
+        "WBT_UnitTest"
     ],
     "Lua.workspace.ignoreDir": [ "/libs" ],
     "Lua.completion.enable": false


### PR DESCRIPTION
Fixes #118 